### PR TITLE
add version tag for spring-boot-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>2.1.5.RELEASE</version>
                 <configuration>
                     <mainClass>community.flock.eco.workday.ApplicationKt</mainClass>
                 </configuration>


### PR DESCRIPTION
the spring-boot-maven-plugin had a missing version tag. I added and assumed the version based on the last commit change of the section.