### PR TITLE
Hotfix client service

### DIFF
--- a/src/main/kotlin/services/ClientService.kt
+++ b/src/main/kotlin/services/ClientService.kt
@@ -4,16 +4,15 @@ import community.flock.eco.core.utils.toNullable
 import community.flock.eco.workday.forms.ClientForm
 import community.flock.eco.workday.model.Client
 import community.flock.eco.workday.repository.ClientRepository
+import javax.transaction.Transactional
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
-import javax.transaction.Transactional
-
 
 @Service
 class ClientService(
-        private val clientRepository: ClientRepository) {
-
+    private val clientRepository: ClientRepository
+) {
     fun findAll(page: Pageable): Page<Client> = clientRepository
             .findAll(page)
 
@@ -32,7 +31,7 @@ class ClientService(
                 form.internalize(it).save() }
 
     @Transactional
-    fun delete(code: String):Unit = clientRepository
+    fun delete(code: String): Unit = clientRepository
             .deleteByCode(code)
 
     private fun ClientForm.internalize(it: Client? = null) = Client(
@@ -41,7 +40,4 @@ class ClientService(
     )
 
     private fun Client.save() = clientRepository.save(this)
-
 }
-
-

--- a/src/main/kotlin/services/ClientService.kt
+++ b/src/main/kotlin/services/ClientService.kt
@@ -27,10 +27,9 @@ class ClientService(
             .save()
 
     @Transactional
-    fun update(code: String, form: ClientForm): Client? = clientRepository
-            .findByCode(code)
-            .toNullable()
-            ?.let { form.internalize(it).save() }
+    fun update(code: String, form: ClientForm): Client? = this.findByCode(code)
+            ?.let {
+                form.internalize(it).save() }
 
     @Transactional
     fun delete(code: String):Unit = clientRepository


### PR DESCRIPTION
+ apply DRY (code cosmetics)
The update function used the findByCode function from the ClientRepository instead of the ClientService. Saves about 2 lines of code 🎈 
+ run code linter ktlint over ClientService
+ fix non-autofixable code violations