### PR TITLE
Hotfix AddActionFab

### DIFF
--- a/src/main/react/components/FabButtons.js
+++ b/src/main/react/components/FabButtons.js
@@ -1,0 +1,30 @@
+import React from "react"
+import AddIcon from "@material-ui/icons/Add"
+import {Fab} from "@material-ui/core"
+import {makeStyles} from "@material-ui/styles"
+
+const useStyles = makeStyles(() => ({
+  root: {
+    position: "absolute",
+    bottom: 25,
+    right: 25,
+  },
+}))
+
+/** AddActionFab
+ * creates a floating action button with the AddIcon from @material-ui/icons
+ * @param {*} props
+ */
+const AddActionFab = props => {
+  const classes = useStyles()
+
+  return (
+    <Fab className={classes.root} {...props}>
+      <AddIcon />
+    </Fab>
+  )
+}
+
+AddActionFab.propTypes = {}
+
+export {AddActionFab}

--- a/src/main/react/components/FabButtons.js
+++ b/src/main/react/components/FabButtons.js
@@ -5,9 +5,9 @@ import {makeStyles} from "@material-ui/styles"
 
 const useStyles = makeStyles(() => ({
   root: {
-    position: "absolute",
-    bottom: 25,
-    right: 25,
+    position: "fixed",
+    bottom: 16,
+    right: 16,
   },
 }))
 

--- a/src/main/react/features/assignments/AssignmentFeature.js
+++ b/src/main/react/features/assignments/AssignmentFeature.js
@@ -2,21 +2,15 @@ import React, {useContext, useEffect, useState} from "react"
 import UserAuthorityUtil from "@flock-eco/feature-user/src/main/react/user_utils/UserAuthorityUtil"
 import Grid from "@material-ui/core/Grid"
 import {makeStyles} from "@material-ui/core"
-import Fab from "@material-ui/core/Fab"
-import AddIcon from "@material-ui/icons/Add"
 import {UserSelector} from "../../components/UserSelector"
 import {AssignmentList} from "./AssignmentList"
 import {ApplicationContext} from "../../application/ApplicationContext"
 import {ClientDialog} from "../client/ClientDialog"
+import {AddActionFab} from "../../components/FabButtons"
 
 const useStyles = makeStyles({
   root: {
     padding: 20,
-  },
-  fab: {
-    position: "absolute",
-    bottom: "25px",
-    right: "25px",
   },
 })
 
@@ -63,9 +57,7 @@ export function AssignmentFeature() {
       </Grid>
 
       <ClientDialog code={dialog.code} open={dialog.open} onClose={handleClose} />
-      <Fab color="primary" className={classes.fab} onClick={handleClickAdd}>
-        <AddIcon />
-      </Fab>
+      <AddActionFab color="primary" onClick={handleClickAdd} />
     </div>
   )
 }

--- a/src/main/react/features/client/ClientFeature.js
+++ b/src/main/react/features/client/ClientFeature.js
@@ -1,19 +1,12 @@
 import React, {useState} from "react"
-
 import {makeStyles} from "@material-ui/core"
-import Fab from "@material-ui/core/Fab"
-import AddIcon from "@material-ui/icons/Add"
 import {ClientList} from "./ClientList"
 import {ClientDialog} from "./ClientDialog"
+import {AddActionFab} from "../../components/FabButtons"
 
 const useStyles = makeStyles({
   root: {
     padding: 10,
-  },
-  fab: {
-    position: "absolute",
-    bottom: "25px",
-    right: "25px",
   },
 })
 
@@ -53,9 +46,7 @@ export function ClientFeature() {
     <>
       <ClientList reload={reload} onItemClick={handleItem} />
       <ClientDialog code={dialog.code} open={dialog.open} onClose={handleClose} />
-      <Fab color="primary" className={classes.fab} onClick={handleAdd}>
-        <AddIcon />
-      </Fab>
+      <AddActionFab color="primary" onClick={handleAdd} />
     </>
   )
 }

--- a/src/main/react/features/holiday/HolidayFeature.js
+++ b/src/main/react/features/holiday/HolidayFeature.js
@@ -1,7 +1,4 @@
 import React, {useContext, useEffect, useState} from "react"
-
-import Fab from "@material-ui/core/Fab"
-import AddIcon from "@material-ui/icons/Add"
 import {makeStyles} from "@material-ui/core/styles"
 import Grid from "@material-ui/core/Grid"
 import UserAuthorityUtil from "@flock-eco/feature-user/src/main/react/user_utils/UserAuthorityUtil"
@@ -10,15 +7,11 @@ import {HolidayList} from "./HolidayList"
 import {UserSelector} from "../../components/UserSelector"
 import HolidayClient from "../../clients/HolidayClient"
 import {ApplicationContext} from "../../application/ApplicationContext"
+import {AddActionFab} from "../../components/FabButtons"
 
 const useStyles = makeStyles({
   root: {
     padding: 20,
-  },
-  fab: {
-    position: "absolute",
-    bottom: "25px",
-    right: "25px",
   },
 })
 
@@ -92,9 +85,7 @@ export function HolidayFeature() {
         onComplete={handleCompleteDialog}
       />
 
-      <Fab color="primary" className={classes.fab} onClick={handleClickAdd}>
-        <AddIcon />
-      </Fab>
+      <AddActionFab color="primary" onClick={handleClickAdd} />
     </div>
   )
 }


### PR DESCRIPTION
+ apply DRY
+ fix display bug of Fab

The display bug occured when the page content increased. The button stayed on the same position moving upwards in the page, the more content was generated