### PR TITLE
add partial state back to handleDrawer functions

### DIFF
--- a/src/main/react/application/Application.js
+++ b/src/main/react/application/Application.js
@@ -46,11 +46,13 @@ export const Application = () => {
   }, [])
 
   function handleDrawerClose() {
-    setState({openDrawer: false})
+    // change openDrawer from state, but keep loggedIn and authorities
+    setState({openDrawer: false, ...state})
   }
 
   function handleDrawerOpen() {
-    setState({openDrawer: true})
+    // change openDrawer from state, but keep loggedIn and authorities
+    setState({openDrawer: true, ...state})
   }
 
   if (state.loggedIn != null && !state.loggedIn) {


### PR DESCRIPTION
accedently removed the ...state from setState. It is required since it populates the other state fields. Without the spread operator on state the loggedIn and authorities would be lost.

Signed-off-by: Tobias Kuppens Groot <tkuppensgroo@uos.de>