### PR TITLE
fix UserSelector component

### DIFF
--- a/src/main/react/components/UserSelector.js
+++ b/src/main/react/components/UserSelector.js
@@ -40,10 +40,7 @@ export function UserSelector(props) {
         <FormControl fullWidth>
           <InputLabel>Select user</InputLabel>
           <Select value={selected || {}} onChange={handleChange}>
-            {users &&
-              users.map(user => {
-                return renderMenuItem(user)
-              })}
+            {users.map(renderMenuItem)}
           </Select>
         </FormControl>
       </CardContent>

--- a/src/main/react/components/UserSelector.js
+++ b/src/main/react/components/UserSelector.js
@@ -22,8 +22,10 @@ export function UserSelector(props) {
   }, [])
 
   function handleChange(event) {
-    setSelected(event.target.value)
-    if (onChange) onChange(selected)
+    // eslint-disable-next-line no-shadow
+    const selected = event.target.value
+    setSelected(selected)
+    onChange(selected)
   }
 
   function renderMenuItem(user) {

--- a/src/main/react/components/UserSelector.js
+++ b/src/main/react/components/UserSelector.js
@@ -8,9 +8,10 @@ import CardContent from "@material-ui/core/CardContent"
 import FormControl from "@material-ui/core/FormControl"
 import UserClient from "@flock-eco/feature-user/src/main/react/user/UserClient"
 
-export function UserSelector({onChange}) {
   const [users, setUsers] = useState(null)
   const [selected, setSelected] = useState("")
+export function UserSelector(props) {
+  const {defaultUser, onChange} = props
 
   useEffect(() => {
     UserClient.findAllUsers("", 0, 100).then(res => {

--- a/src/main/react/components/UserSelector.js
+++ b/src/main/react/components/UserSelector.js
@@ -52,5 +52,8 @@ export function UserSelector(props) {
 }
 
 UserSelector.propTypes = {
-  onChange: PropTypes.func,
+  defaultUser: PropTypes.shape({
+    code: PropTypes.string.isRequired,
+  }),
+  onChange: PropTypes.func.isRequired,
 }

--- a/src/main/react/components/UserSelector.js
+++ b/src/main/react/components/UserSelector.js
@@ -7,6 +7,7 @@ import {Card} from "@material-ui/core"
 import CardContent from "@material-ui/core/CardContent"
 import FormControl from "@material-ui/core/FormControl"
 import UserClient from "@flock-eco/feature-user/src/main/react/user/UserClient"
+import {isUndefined} from "../utils/validation"
 
 export function UserSelector(props) {
   const {defaultUser, onChange} = props
@@ -15,9 +16,19 @@ export function UserSelector(props) {
 
   useEffect(() => {
     UserClient.findAllUsers("", 0, 100).then(res => {
+      let selectedItem = null
       console.log(res)
       setUsers(res.list)
-      setSelected(res.list[0])
+      if (isUndefined(defaultUser)) {
+        ;[selectedItem] = res.list
+        onChange(selectedItem)
+      } else {
+        ;[selectedItem] = res.list.filter(it =>
+          it.code === defaultUser.code ? it : null
+        )
+      }
+
+      setSelected(selectedItem)
     })
   }, [])
 

--- a/src/main/react/components/UserSelector.js
+++ b/src/main/react/components/UserSelector.js
@@ -8,10 +8,10 @@ import CardContent from "@material-ui/core/CardContent"
 import FormControl from "@material-ui/core/FormControl"
 import UserClient from "@flock-eco/feature-user/src/main/react/user/UserClient"
 
-  const [users, setUsers] = useState(null)
-  const [selected, setSelected] = useState("")
 export function UserSelector(props) {
   const {defaultUser, onChange} = props
+  const [users, setUsers] = useState([])
+  const [selected, setSelected] = useState({})
 
   useEffect(() => {
     UserClient.findAllUsers("", 0, 100).then(res => {

--- a/src/main/react/features/holiday/HolidayFeature.js
+++ b/src/main/react/features/holiday/HolidayFeature.js
@@ -67,7 +67,7 @@ export function HolidayFeature() {
       <Grid container spacing={1}>
         <UserAuthorityUtil has={"HolidayAuthority.ADMIN"}>
           <Grid item xs={12}>
-            <UserSelector onChange={handleChangeUser} />
+            <UserSelector defaultUser={user} onChange={handleChangeUser} />
           </Grid>
         </UserAuthorityUtil>
         <Grid item xs={12}>


### PR DESCRIPTION
The user selector component selected the first user from UserClient.findAllUsers by default, this didnt inline with the default HolidayList where the entries of the current user were shown.
Additionally when selecting a user from the UserSelector the components handleChange function didnt return the correct selected item to the onChange parent handler resulting in displaying the previous selected user instead of the currently selected user.

+ create defaultUser for selection
+ fix onChange return param
