### PR TITLE
fix delimiter for multiple file extentions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,14 +7,14 @@ end_of_line = lf
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[*.{java|kt|gradle}]
+[*.{java,kt,gradle}]
 indent_size = 4
 
-[*.{yaml|yml}]
+[*.{yaml,yml}]
 indent_size = 2
 
 [*.{xml}]
 indent_size = 4
 
-[*.{js|jsx|ts|tsx|css|sass|scss|html}]
+[*.{js,jsx,ts,tsx,css,sass,scss,html}]
 indent_size = 2


### PR DESCRIPTION
+ replace | with "," since it´s the correct delimiter in a editorconfig file

Signed-off-by: Tobias Kuppens Groot <tkuppensgroo@uos.de>