### PR TITLE
Hotfix holiday form

### DIFF
--- a/src/main/kotlin/forms/HolidayForm.kt
+++ b/src/main/kotlin/forms/HolidayForm.kt
@@ -9,7 +9,7 @@ import java.time.LocalDate
 
 data class HolidayForm(
 
-    val description: String?,
+    val description: String,
     val status: HolidayStatus? = null,
 
     @JsonDeserialize(using = LocalDateDeserializer::class)

--- a/src/main/kotlin/model/Holiday.kt
+++ b/src/main/kotlin/model/Holiday.kt
@@ -20,7 +20,7 @@ data class Holiday(
     override val id: Long = 0,
     override val code: String = UUID.randomUUID().toString(),
 
-    val description: String?,
+    val description: String,
 
     @Enumerated(EnumType.STRING)
     val status: HolidayStatus,

--- a/src/main/react/features/holiday/HolidayForm.js
+++ b/src/main/react/features/holiday/HolidayForm.js
@@ -31,6 +31,7 @@ export function HolidayForm(props) {
     } else {
       const now = moment()
       setState({
+        description: "",
         period: {
           dates: [now, now],
           days: [8],


### PR DESCRIPTION
+ fix the warning: a component is changing an uncontrolled input of type text to be controlled. Input elements should not switch from uncontrolled to controlled
+ change description field to be notNullable since the HolidayForm in the frontend requires the description to be able to successfully submit the form.